### PR TITLE
fix: add reusable scan user table in scans page

### DIFF
--- a/resources/js/Pages/Scan/Index.jsx
+++ b/resources/js/Pages/Scan/Index.jsx
@@ -3,6 +3,7 @@ import { Head } from '@inertiajs/react'
 import { Column } from 'primereact/column'
 import { DataTable } from 'primereact/datatable'
 import { format } from "date-fns";
+import ScanUserTable from '@/Components/tables/ScanUserTable';
 
 export default function Index({ auth, scans }) {
     const createdAtBody = (str) => {
@@ -16,7 +17,7 @@ export default function Index({ auth, scans }) {
 
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
-
+                    <ScanUserTable scans={scans} />
                 </div>
             </div>
         </AuthenticatedLayout>


### PR DESCRIPTION
This pull request fixes issue of missing scan user table in scans page